### PR TITLE
Added option for max allowed health

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.ikevoodoo</groupId>
     <artifactId>lifesteal-smp-plugin</artifactId>
-    <version>1.6.3.0</version>
+    <version>1.6.4.0</version>
     <packaging>jar</packaging>
 
     <name>Lifesteal Smp Plugin</name>

--- a/src/main/java/me/ikevoodoo/lifestealsmpplugin/Configuration.java
+++ b/src/main/java/me/ikevoodoo/lifestealsmpplugin/Configuration.java
@@ -23,6 +23,9 @@ public class Configuration {
 
     private static double scaleAmount, scaleAmountHP;
 
+    private static boolean cappedHealth;
+    private static double cappedMaxHealth;
+
     private static final HashMap<String, Object> configKeys = new HashMap<>();
 
     private static final List<UUID> eliminated = new ArrayList<>();
@@ -42,6 +45,9 @@ public class Configuration {
 
         configKeys.put("elimination.scaleHealth", true);
         configKeys.put("elimination.healthScale", 1.0D);
+
+        configKeys.put("elimination.cappedHealth", false);
+        configKeys.put("elimination.cappedMaxHealth", 80D);
         scaleAmountHP = 2.0D;
     }
 
@@ -79,6 +85,8 @@ public class Configuration {
         // 1.0 Hearts -> 2.0 HP
         // 1.5 Hearts -> 2.5 HP
         scaleAmountHP = Utils.parseHearts(scaleAmount);
+        cappedHealth = configuration.getBoolean("elimination.cappedHealth");
+        cappedMaxHealth = configuration.getDouble("elimination.cappedMaxHealth") * 2;
 
         List<UUID> tempEliminated = new ArrayList<>();
         if(configuration.contains("eliminated")) {
@@ -161,6 +169,13 @@ public class Configuration {
         return scaleAmountHP;
     }
 
+    public static boolean isCappedHealth() {
+        return cappedHealth;
+    }
+
+    public static double getMaxAllowedHealth() {
+        return cappedMaxHealth;
+    }
 
     public static void addElimination(Player player, UUID killerId) {
         if(killerId != null) {

--- a/src/main/java/me/ikevoodoo/lifestealsmpplugin/Utils.java
+++ b/src/main/java/me/ikevoodoo/lifestealsmpplugin/Utils.java
@@ -21,7 +21,7 @@ public class Utils {
 
     public static void modifyHealth(Player player, double scale) {
         AttributeInstance maxHp = getMaxHealth(player);
-
+        double finalHealth = maxHp.getValue() + scale;
         if(maxHp.getBaseValue() + scale <= 0) {
             maxHp.setBaseValue(20);
             if(Configuration.environmentStealsHearts() && player.getKiller() == null)
@@ -29,7 +29,7 @@ public class Utils {
             else if(player.getKiller() != null)
                 eliminate(player, player.getKiller());
         }
-        else maxHp.setBaseValue(maxHp.getValue() + scale);
+        else if(!Configuration.isCappedHealth() || finalHealth<= Configuration.getMaxAllowedHealth()) maxHp.setBaseValue(maxHp.getValue() + scale);
 
         if(Configuration.shouldScaleHealth() && player.getHealth() + scale > 0) player.setHealth(player.getHealth() + scale);
     }

--- a/src/main/java/me/ikevoodoo/lifestealsmpplugin/Utils.java
+++ b/src/main/java/me/ikevoodoo/lifestealsmpplugin/Utils.java
@@ -31,7 +31,7 @@ public class Utils {
         }
         else if(!Configuration.isCappedHealth() || finalHealth<= Configuration.getMaxAllowedHealth()) maxHp.setBaseValue(maxHp.getValue() + scale);
 
-        if(Configuration.shouldScaleHealth() && player.getHealth() + scale > 0) player.setHealth(player.getHealth() + scale);
+        if(Configuration.shouldScaleHealth() && player.getHealth() + scale > 0 && (player.getHealth() + scale) <= maxHp.getValue()) player.setHealth(player.getHealth() + scale);
     }
 
     public static void eliminate(Player player, Player killer) {


### PR DESCRIPTION
Config controllable option for max allowed health whenever a player kills someone else.
Players cant go over that health (in hearts) and cant become too op
Commands such as /lshealth still bypass that rule to allow admins to make exceptions