### PR TITLE
Fix heart farming exploit

### DIFF
--- a/src/main/java/me/ikevoodoo/lssmp/listeners/PlayerPreDeathListener.java
+++ b/src/main/java/me/ikevoodoo/lssmp/listeners/PlayerPreDeathListener.java
@@ -28,7 +28,7 @@ public class PlayerPreDeathListener extends SMPListener {
         if(!MainConfig.Elimination.isWorldAllowed(world))
             return;
 
-        if(event.hasKiller() && event.getKiller() instanceof Player killer) {
+        if(event.hasKiller() && event.getKiller() instanceof Player killer && (!MainConfig.Elimination.useMinHealth || HealthUtils.get(player) > MainConfig.Elimination.getMin())) {
             Util.increaseOrDrop(
                     MainConfig.Elimination.healthScale * 2,
                     MainConfig.Elimination.getMax(),

--- a/src/main/java/me/ikevoodoo/lssmp/listeners/PlayerPreDeathListener.java
+++ b/src/main/java/me/ikevoodoo/lssmp/listeners/PlayerPreDeathListener.java
@@ -27,8 +27,11 @@ public class PlayerPreDeathListener extends SMPListener {
 
         if(!MainConfig.Elimination.isWorldAllowed(world))
             return;
-
-        if(event.hasKiller() && event.getKiller() instanceof Player killer && (!MainConfig.Elimination.useMinHealth || HealthUtils.get(player) > MainConfig.Elimination.getMin())) {
+        
+        if (MainConfig.Elimination.useMinHealth && HealthUtils.get(player) <= MainConfig.Elimination.getMin())
+            return;
+        
+        if(event.hasKiller() && event.getKiller() instanceof Player killer) {
             Util.increaseOrDrop(
                     MainConfig.Elimination.healthScale * 2,
                     MainConfig.Elimination.getMax(),


### PR DESCRIPTION
This patch prevents giving hearts if config uses min health and the killed player is at minimum.
Without the patch and if using the minimum then 2 players could team up to restore their health: player A kills player B until player A is at max, then player B kills player A until they equalize their health.

also mentioned here: https://github.com/IkeVoodoo/LSSMP/issues/209