### PR TITLE
Fix several legal issues

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2023 IkeVoodoo
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,6 @@ Available on Aternos and Minehut.
 
 This project is a recreation of the plugin found in this series: https://www.youtube.com/watch?v=M1hSXtHSAmU
 
-# NOTE
-
-  - You are allowed to edit this plugin only for private use
-  - You are not allowed to redistribute the plugin anywhere, unless permission specifically granted by me
-  - You are allowed to make a pull request if you feel like you made a good change
-  - You are not allowed to take code from this plugin if you use it in a commercial product
-  - You are allowed to use this plugin on your server, regardless if it has monetization or not and the server follows the mojang [EULA](https://account.mojang.com/documents/minecraft_eula)
-
 Download on [SpigotMC](https://www.spigotmc.org/resources/lifesteal-smp-plugin.94387/)
 
 Join the [Discord](https://refinedtech.dev/discord)


### PR DESCRIPTION
This PR fixes two issues with the project's licensing:
1. Fixes copyright for the license. The license belongs to the Free Software Foundation, not to the project owner.
2. Removed the irrelevant `NOTE` section from the README. The issues with each bullet are as follows:
- The [GNU GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html) permits modification for public, private, and commercial use, and by hosting this repository publicly on GitHub, you are agreeing to their [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service), which, under [Section D.5](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#5-license-grant-to-other-users), grants every user the right to fork, modify, clone, and do anything using the built-in GitHub functionality to or with your repository.
- The [GNU GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html) permits redistribution of modified and unmodified copies of software, anywhere, at any time, without prior permission.
- [Section D.5](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#5-license-grant-to-other-users) of the GitHub Terms of Service already permits users to open pull requests on any repository at any time, as this is a subset of permission to use the built-in GitHub functionality.
- The [GNU GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html) permits use of the software for all legal purposes, including commercial use;
- as well as public and private use, including on Minecraft servers, regardless of whether or not the server follows the [Mojang Studios EULA](https://account.mojang.com/documents/minecraft_eula).