### PR TITLE
Fix duplication exploits when minimum health is used

### DIFF
--- a/src/main/java/me/ikevoodoo/lssmp/listeners/PlayerPreDeathListener.java
+++ b/src/main/java/me/ikevoodoo/lssmp/listeners/PlayerPreDeathListener.java
@@ -47,19 +47,21 @@ public class PlayerPreDeathListener extends SMPListener {
             return;
         }
 
-        Util.increaseOrDrop(
-                elimination.getHeartScale(),
-                elimination.getMax(),
-                killer,
-                killed.getEyeLocation(),
-                getPlugin()
-        );
-
         var result = getPlugin().getHealthHelper().decreaseMaxHealthIfOver(
                 killed,
                 elimination.getHeartScale(),
                 elimination.getMinHearts()
         );
+
+        if (!elimination.useMinHealth || result.oldHealth() > elimination.getMinHearts()) {
+            Util.increaseOrDrop(
+                    elimination.getHeartScale(),
+                    elimination.getMax(),
+                    killer,
+                    killed.getEyeLocation(),
+                    getPlugin()
+            );
+        }
 
         if(result.newHealth() <= elimination.getMinHearts() && elimination.banAtMinHealth())
             eliminate(killed);
@@ -91,21 +93,23 @@ public class PlayerPreDeathListener extends SMPListener {
             return;
         }
 
-        if(elimination.alwaysDropHearts() || elimination.environmentDropHearts()) {
-            Util.drop(
-                    getPlugin()
-                            .getItem("heart_item")
-                            .orElseThrow()
-                            .getItemStack(),
-                    player.getEyeLocation()
-            );
-        }
-
         var setResult = getPlugin().getHealthHelper().decreaseMaxHealthIfOver(
                 player,
                 elimination.getEnvironmentHeartScale(),
                 elimination.getMinHearts()
         );
+
+        if (elimination.alwaysDropHearts() || elimination.environmentDropHearts()) {
+            if (!elimination.useMinHealth || setResult.oldHealth() > elimination.getMinHearts()) {
+                Util.drop(
+                        getPlugin()
+                                .getItem("heart_item")
+                                .orElseThrow()
+                                .getItemStack(),
+                        player.getEyeLocation()
+                );
+            }
+        }
 
         if(setResult.newHealth() <= elimination.getMinHearts() && elimination.banAtMinHealth())
             eliminate(player);


### PR DESCRIPTION
This fixes two duplication exploits when minimum health is used.

1. When a player is killed in PvP, the killer no longer receives a heart if the killed player was already at minimum health.
2. When a player is killed by environment and heart drops are enabled, no heart is dropped if the player was already at minimum health.

Both of these exploits are present in the v3 branch of this repo.

Sadly I can't check whether my changes work correctly, because this plugin is currently not buildable. It seems like the SMPCore repo is missing an update (there is no `me.ikevoodoo.smpcore.config2` package in the available SMPCore code).